### PR TITLE
Fix:Fix/average precision score single sample 30615

### DIFF
--- a/sklearn/metrics/_ranking.py
+++ b/sklearn/metrics/_ranking.py
@@ -219,6 +219,14 @@ def average_precision_score(
     def _binary_uninterpolated_average_precision(
         y_true, y_score, pos_label=1, sample_weight=None
     ):
+        
+        if len(y_true) < 2:
+            raise ValueError(
+                "Average precision requires at least 2 samples to compute a meaningful "
+                "score. A single sample cannot form a precision-recall curve. "
+                f"Got array with shape ({len(y_true)},)"
+            )
+   
         precision, recall, _ = precision_recall_curve(
             y_true, y_score, pos_label=pos_label, sample_weight=sample_weight
         )

--- a/sklearn/metrics/_ranking.py
+++ b/sklearn/metrics/_ranking.py
@@ -220,25 +220,14 @@ def average_precision_score(
 
     def _binary_uninterpolated_average_precision(
         y_true, y_score, pos_label=1, sample_weight=None
-<<<<<<< HEAD
-    ):  
+
+    ):
         if len(y_true) < 2:
             raise ValueError(
                 f"Average precision requires at least 2 samples. Got {len(y_true)}."
                 " A single sample cannot form a precision-recall curve."
             )
 
-=======
-    ):
-        
-        if len(y_true) < 2:
-            raise ValueError(
-                "Average precision requires at least 2 samples to compute a meaningful "
-                "score. A single sample cannot form a precision-recall curve. "
-                f"Got array with shape ({len(y_true)},)"
-            )
-   
->>>>>>> 2f224d2fb39498443d7d56a73d0261284425880f
         precision, recall, _ = precision_recall_curve(
             y_true, y_score, pos_label=pos_label, sample_weight=sample_weight
         )

--- a/sklearn/metrics/_ranking.py
+++ b/sklearn/metrics/_ranking.py
@@ -220,7 +220,13 @@ def average_precision_score(
 
     def _binary_uninterpolated_average_precision(
         y_true, y_score, pos_label=1, sample_weight=None
-    ):
+    ):  
+        if len(y_true) < 2:
+            raise ValueError(
+                f"Average precision requires at least 2 samples. Got {len(y_true)}."
+                " A single sample cannot form a precision-recall curve."
+            )
+
         precision, recall, _ = precision_recall_curve(
             y_true, y_score, pos_label=pos_label, sample_weight=sample_weight
         )


### PR DESCRIPTION
Fixes #30615
## Fix for Issue #30615 - average_precision_score with single sample

### Solution
I solved this by adding a validation check in the `_binary_uninterpolated_average_precision` function to ensure there are at least two samples before attempting to calculate the average precision score.

### Implementation

```python
def _binary_uninterpolated_average_precision(
    y_true, y_score, pos_label=1, sample_weight=None
):
    # Add validation for minimum samples
    if len(y_true) < 2:
              raise ValueError(
                  f"Average precision requires at least 2 samples. Got {len(y_true)}."
                  " A single sample cannot form a precision-recall curve."
              )
    
    precision, recall, _ = precision_recall_curve(
        y_true, y_score, pos_label=pos_label, sample_weight=sample_weight
    )
    # Return the step function integral
    return max(0.0, -np.sum(np.diff(recall) * np.array(precision)[:-1]))
```

### Changes
- Added input validation to check for minimum number of samples
- Improved error message that explains why single sample computation is not possible
- Follows scikit-learn's error messaging conventions


Let me clearly explain the changes in a before/after format to show exactly what was modified in the codebase.

BEFORE (Original Code):
```python
def _binary_uninterpolated_average_precision(
    y_true, y_score, pos_label=1, sample_weight=None
):
    precision, recall, _ = precision_recall_curve(
        y_true, y_score, pos_label=pos_label, sample_weight=sample_weight
    )
    # Return the step function integral
    return max(0.0, -np.sum(np.diff(recall) * np.array(precision)[:-1]))
```

AFTER (Fixed Code):

```python
def _binary_uninterpolated_average_precision(
    y_true, y_score, pos_label=1, sample_weight=None
):
    # Add validation for minimum samples
    if len(y_true) < 2:
              raise ValueError(
                  f"Average precision requires at least 2 samples. Got {len(y_true)}."
                  " A single sample cannot form a precision-recall curve."
              )
    
    precision, recall, _ = precision_recall_curve(
        y_true, y_score, pos_label=pos_label, sample_weight=sample_weight
    )
    # Return the step function integral
    return max(0.0, -np.sum(np.diff(recall) * np.array(precision)[:-1]))
```

